### PR TITLE
ベンチマーカー初回実行→INDEXと取得カラムの見直し

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ docker run --network host -i private-isu-benchmarker /bin/benchmarker -t http://
 docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata
 ```
 
+kona独自のエラーでベンチマーカー実行時に`database isuconp が見つからない`となるので、mysqlコンテナにログインしてSQLを流した。
+
+```sh
+cat dump.sql | mysql -uroot -proot
+```
+
 動かない場合は`ip a`してdocker0のインタフェースでホストのIPアドレスを調べて`host.docker.internal`の代わりに指定する。以下の場合は`172.17.0.1`を指定する。
 
 ```

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   app:
     build:
       # Go実装の場合は golang/ PHP実装の場合は php/
-      context: ruby/
+      context: golang/
       dockerfile: Dockerfile
     depends_on:
       - mysql

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - mysql:/var/lib/mysql
       - ./sql:/docker-entrypoint-initdb.d
       - ./logs/mysql:/var/log/mysql
+      # - ./mysql/my.cnf:/etc/mysql/my.cnf
     ports:
       - "3306:3306"
     networks:

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -175,7 +175,7 @@ func makePosts(results []Post, csrfToken string, allComments bool) ([]Post, erro
 	var posts []Post
 
 	for _, p := range results {
-		err := db.Get(&p.CommentCount, "SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = ?", p.ID)
+		err := db.Get(&p.CommentCount, "SELECT COUNT(id) AS `count` FROM `comments` WHERE `post_id` = ?", p.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -419,7 +419,7 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 	accountName := r.PathValue("accountName")
 	user := User{}
 
-	err := db.Get(&user, "SELECT * FROM `users` WHERE `account_name` = ? AND `del_flg` = 0", accountName)
+	err := db.Get(&user, "SELECT `id`, `account_name`, `authority` FROM `users` WHERE `account_name` = ? AND `del_flg` = 0", accountName)
 	if err != nil {
 		log.Print(err)
 		return
@@ -445,7 +445,7 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	commentCount := 0
-	err = db.Get(&commentCount, "SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = ?", user.ID)
+	err = db.Get(&commentCount, "SELECT COUNT(id) AS count FROM `comments` WHERE `user_id` = ?", user.ID)
 	if err != nil {
 		log.Print(err)
 		return
@@ -473,7 +473,7 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 			args[i] = v
 		}
 
-		err = db.Get(&commentedCount, "SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN ("+placeholder+")", args...)
+		err = db.Get(&commentedCount, "SELECT COUNT(id) AS count FROM `comments` WHERE `post_id` IN ("+placeholder+")", args...)
 		if err != nil {
 			log.Print(err)
 			return

--- a/webapp/mysql/my.cnf
+++ b/webapp/mysql/my.cnf
@@ -1,0 +1,8 @@
+[mysqld]
+innodb_flush_method = O_DIRECT
+innodb_flush_log_at_trx_commit = 0 # or 2
+slow_query_log                 = 1
+slow_query_log_file            = /var/lib/mysql/mysqld-slow.log
+long_query_time                = 0
+log-queries-not-using-indexes  = 1
+innodb_buffer_pool_size        = 1G # スペックに合わせて調整


### PR DESCRIPTION
このPR段階で貼ったINDEX

```sql
-- users
alter table users add index user_name_del_index(account_name, del_flg);

-- posts
alter table posts add index post_user_id_created_at_index(user_id, created_at);

-- comments
alter table comments add index comment_user_id_index(user_id);
alter table comments add index comment_post_id_index(post_id);
```